### PR TITLE
Update strings exercise numbering

### DIFF
--- a/pretext/Strings/Exercises.ptx
+++ b/pretext/Strings/Exercises.ptx
@@ -1,67 +1,63 @@
 <?xml version="1.0"?>
 <exercises xml:id="strings_exercises">
   <title>Exercises</title>
-  <p>
-    <ol marker="1">
-      <li>
-        <exercise>
-          <statement/>
-          <program interactive="" language=""/>
-          <solution>
-                        
-                            
-                                &#x2018;Python'[1] = &#x2018;y'
-                            
-                            
-                                &#x2018;Strings are sequences of characters.'[5] = &#x2018;g'
-                            
-                            
-                                len(&#x2018;wonderful') = 9
-                            
-                            
-                                &#x2018;Mystery'[:4] = &#x2018;Myst'
-                            
-                            
-                                &#x2018;p' in &#x2018;Pineapple' = True
-                            
-                            
-                                &#x2018;apple' in &#x2018;Pineapple' = True
-                            
-                            
-                                &#x2018;pear' not in &#x2018;Pineapple' = True
-                            
-                            
-                                &#x2018;apple' &gt; &#x2018;pineapple' = False
-                            
-                            
-                                &#x2018;pineapple' &lt; &#x2018;Peach' = False
-                            
-                        
-                    
-                        <p><ol marker="a"><li><p>&#x2018;Python'[1] = &#x2018;y'</p></li><li><p>&#x2018;Strings are sequences of characters.'[5] = &#x2018;g'</p></li><li><p>len(&#x2018;wonderful') = 9</p></li><li><p>&#x2018;Mystery'[:4] = &#x2018;Myst'</p></li><li><p>&#x2018;p' in &#x2018;Pineapple' = True</p></li><li><p>&#x2018;apple' in &#x2018;Pineapple' = True</p></li><li><p>&#x2018;pear' not in &#x2018;Pineapple' = True</p></li><li><p>&#x2018;apple' &gt; &#x2018;pineapple' = False</p></li><li><p>&#x2018;pineapple' &lt; &#x2018;Peach' = False</p></li></ol></p>
-                    </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_2">
-          <statement>
-            <p>In Robert McCloskey's
-                    book <em>Make Way for Ducklings</em>, the names of the ducklings are Jack, Kack, Lack,
-                    Mack, Nack, Ouack, Pack, and Quack.  This loop tries to output these names in order.</p>
-            <program language="python">
-              <input>
+  <exercise>
+    <statement>
+      <p>What is the result of each of the following:
+        <ol marker="a">
+          <li><c>'Python'[1]</c></li>
+          <li><c>"Strings are sequences of characters."[5]</c></li>
+          <li><c>len("wonderful")</c></li>
+          <li><c>'Mystery'[:4]</c></li>
+          <li><c>'p' in 'Pineapple'</c></li>
+          <li><c>'apple' in 'Pineapple'</c></li>
+          <li><c>'pear' not in 'Pineapple'</c></li>
+          <li><c>'apple' &gt; 'pineapple'</c></li>
+          <li><c>'pineapple' &lt; 'Peach'</c></li>
+        </ol>
+      </p>
+    </statement>
+    <program interactive="activecode" language="python">
+      <input>
+
+      </input>
+    </program> 
+    <solution>     
+      <p>
+        <ol marker="a">
+          <li><p>'Python'[1] = <c>'y'</c></p></li>
+          <li><p>'Strings are sequences of characters.'[5] = <c>'g'</c></p></li>
+          <li><p>len('wonderful') = <c>9</c></p></li>
+          <li><p>'Mystery'[:4] = <c>'Myst'</c></p></li>
+          <li><p>'p' in 'Pineapple' = <c>True</c></p></li>
+          <li><p>'apple' in 'Pineapple' = <c>True</c></p></li>
+          <li><p>'pear' not in 'Pineapple' = <c>True</c></p></li>
+          <li><p>'apple' &gt; 'pineapple' = <c>False</c></p></li>
+          <li><p>'pineapple' &lt; 'Peach' = <c>False</c></p></li>
+        </ol>
+      </p>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_2">
+    <statement>
+      <p>In Robert McCloskey's
+              book <em>Make Way for Ducklings</em>, the names of the ducklings are Jack, Kack, Lack,
+              Mack, Nack, Ouack, Pack, and Quack.  This loop tries to output these names in order.</p>
+      <program language="python">
+        <input>
 prefixes = "JKLMNOPQ"
 suffix = "ack"
 
 for p in prefixes:
     print(p + suffix)
-</input>
-            </program>
-            <p>Of course, that's not quite right because Ouack and Quack are misspelled.
-                    Can you fix it?</p>
-          </statement>
-          <program xml:id="ex_8_2_editor" interactive="activecode" language="python">
-            <input>
+        </input>
+      </program>
+      <p>Of course, that's not quite right because Ouack and Quack are misspelled.
+              Can you fix it?</p>
+    </statement>
+    <program xml:id="ex_8_2_editor" interactive="activecode" language="python">
+      <input>
 
 prefixes = "JKLMNOPQ"
 suffix = "ack"
@@ -93,21 +89,24 @@ class myTests(TestCaseGui):
         self.assertNotIn("Oack", o, "Account for the misspellings. Qack should not be in output.")
         self.assertNotIn("Qack", o, "Account for the misspellings. Qack should not be in output.")
 myTests().main()
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_3">
-          <statement>
-            <p>Assign to a variable in your program a triple-quoted string that contains
-                            your favorite paragraph of text - perhaps a poem, a speech, instructions
-                            to bake a cake, some inspirational verses, etc.</p>
-            <p>Write a function that counts the number of alphabetic characters (a through z, or A through Z) in your text and then keeps track of (and returns) how many are the letter &#x2018;e'.  Your function should print an analysis of the text like this:</p>
-            <pre>Your text contains 243 alphabetic characters, of which 109 (44.8%) are 'e'.</pre>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_3_editor">
-            <input>
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_3">
+    <statement>
+      <p>Assign to a variable in your program a triple-quoted string that contains
+                your favorite paragraph of text - perhaps a poem, a speech, instructions
+                to bake a cake, some inspirational verses, etc.
+      </p>
+      <p>Write a function that counts the number of alphabetic characters (a through z, or A through Z) 
+      in your text and then keeps track of (and returns) how many are the letter 'e'.  
+      Your function should print an analysis of the text like this:
+      </p>
+        <pre>Your text contains 243 alphabetic characters, of which 109 (44.8%) are 'e'.</pre>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_3_editor">
+      <input>
 def count(p):
     # your code here
 
@@ -127,11 +126,11 @@ class myTests(TestCaseGui):
         self.assertEqual(count(string3), 12, "Twelve")
         self.assertNotEqual(count(string4), 3, "Has two Es")
 myTests().main()
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q3_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q3_answer" language="python">
+        <input>
 def count(p):
     lows = "abcdefghijklmnopqrstuvwxyz"
     ups =  "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
@@ -160,29 +159,27 @@ once a year, killing everyone inside."
 
 count(p)
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_4">
-          <statement>
-            <p>Print out a neatly formatted multiplication table, up to 12 x 12.</p>
-          </statement>
-          <program xml:id="ex_8_4_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
 
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_7_10">
-          <statement>
-            <p>Write a function that will return the number of digits in an integer.</p>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_7_10_editor">
-            <input>
+  <exercise label="ex_8_4">
+    <statement>
+      <p>Print out a neatly formatted multiplication table, up to 12 x 12.</p>
+    </statement>
+    <program xml:id="ex_8_4_editor" interactive="activecode" language="python">
+      <input>
+
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_7_10">
+    <statement>
+      <p>Write a function that will return the number of digits in an integer.</p>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_7_10_editor">
+      <input>
 def numDigits(n):
     # your code here
 
@@ -199,11 +196,11 @@ class myTests(TestCaseGui):
       self.assertEqual(numDigits(444),3,"Tested numDigits on input of 444")
 
 myTests().main()
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q5_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q5_answer" language="python">
+        <input>
 def numDigits(n):
     n_str = str(n)
     return len(n_str)
@@ -213,17 +210,16 @@ print(numDigits(50))
 print(numDigits(20000))
 print(numDigits(1))
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_5">
-          <statement>
-            <p>Write a function that reverses its string argument.</p>
-          </statement>
-          <program xml:id="ex_8_5_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_5">
+    <statement>
+      <p>Write a function that reverses its string argument.</p>
+    </statement>
+    <program xml:id="ex_8_5_editor" interactive="activecode" language="python">
+      <input>
 def reverse(astring):
     # your code here
 
@@ -242,17 +238,25 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise>
-          <statement/>
-          <program interactive="" language=""/>
-          <solution>
-            <program xml:id="str_q7_answer" language="python">
-              <input>
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="str_q7">
+    <statement>
+      <p>Write a function called <c>mirror</c> 
+        that takes a string as input and returns the input string followed 
+        by the reversed version of the input string.
+      </p>
+    </statement>
+    <program xml:id="str_q7_editor" interactive="activecode" language="python">
+      <input>
+
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q7_answer" language="python">
+        <input>
 from test import testEqual
 
 def reverse(mystr):
@@ -269,17 +273,16 @@ testEqual(mirror('Python'), 'PythonnohtyP')
 testEqual(mirror(''), '')
 testEqual(mirror('a'), 'aa')
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_7">
-          <statement>
-            <p>Write a function that removes all occurrences of a given letter from a string.</p>
-          </statement>
-          <program xml:id="ex_8_7_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_7">
+    <statement>
+      <p>Write a function that removes all occurrences of a given letter from a string.</p>
+    </statement>
+    <program xml:id="ex_8_7_editor" interactive="activecode" language="python">
+      <input>
 def remove_letter(theLetter, theString):
     # your code here
 
@@ -298,17 +301,16 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_8">
-          <statement>
-            <p>Write a function that recognizes palindromes. (Hint: use your <c>reverse</c> function to make this easy!).</p>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_8_editor">
-            <input>
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_8">
+    <statement>
+      <p>Write a function that recognizes palindromes. (Hint: use your <c>reverse</c> function to make this easy!).</p>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_8_editor">
+      <input>
 def is_palindrome(myStr):
     # your code here
 
@@ -330,11 +332,11 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q9_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q9_answer" language="python">
+        <input>
 from test import testEqual
 
 def reverse(mystr):
@@ -355,14 +357,16 @@ testEqual(is_palindrome('straw warts'), True)
 testEqual(is_palindrome('a'), True)
 testEqual(is_palindrome(''), True)
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <p>Write a function that counts how many non-overlapping occurences of a substring appear in a string.</p>
-        <program xml:id="ex_8_9" interactive="activecode" language="python">
-          <input>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise>
+    <statement>
+      <p>Write a function that counts how many non-overlapping occurences of a substring appear in a string.</p>
+    </statement>
+    <program xml:id="ex_8_9" interactive="activecode" language="python">
+      <input>
 def count(substr,theStr):
     # your code here
 
@@ -386,16 +390,16 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-        </program>
-      </li>
-      <li>
-        <exercise label="ex_8_10">
-          <statement>
-            <p>Write a function that removes the first occurrence of a string from another string.</p>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_10_editor">
-            <input>
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_10">
+    <statement>
+      <p>Write a function that removes the first occurrence of a string from another string.</p>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_10_editor">
+      <input>
 def remove(substr,theStr):
     # your code here
 
@@ -415,11 +419,11 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q11_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q11_answer" language="python">
+        <input>
 from test import testEqual
 
 def remove(substr,theStr):
@@ -434,17 +438,16 @@ testEqual(remove('cyc', 'bicycle'), 'bile')
 testEqual(remove('iss', 'Mississippi'), 'Missippi')
 testEqual(remove('egg', 'bicycle'), 'bicycle')
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_11">
-          <statement>
-            <p>Write a function that removes all occurrences of a string from another string.</p>
-          </statement>
-          <program xml:id="ex_8_11_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_11">
+    <statement>
+      <p>Write a function that removes all occurrences of a string from another string.</p>
+    </statement>
+    <program xml:id="ex_8_11_editor" interactive="activecode" language="python">
+      <input>
 def remove_all(substr,theStr):
     # your code here
 
@@ -465,26 +468,25 @@ class myTests(TestCaseGui):
 
 
 myTests().main()
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_12">
-          <statement>
-            <p>Here is another interesting L-System called a Hilbert curve.  Use 90 degrees:</p>
-            <pre>L
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_12">
+    <statement>
+      <p>Here is another interesting L-System called a Hilbert curve.  Use 90 degrees:</p>
+        <pre>L
 L -&gt; +RF-LFL-FR+
 R -&gt; -LF+RFR+FL-</pre>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_12_editor">
-            <input>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_12_editor">
+      <input>
 
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q13_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q13_answer" language="python">
+        <input>
 import turtle
 
 def createLSystem(numIters, axiom):
@@ -541,41 +543,39 @@ def main():
 
 main()
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_13">
-          <statement>
-            <p>Here is a dragon curve.  Use 90 degrees.:</p>
-            <pre>FX
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_13">
+    <statement>
+      <p>Here is a dragon curve.  Use 90 degrees.:</p>
+        <pre>FX
 X -&gt; X+YF+
 Y -&gt; -FX-Y</pre>
-          </statement>
-          <program xml:id="ex_8_13_editor" interactive="activecode" language="python">
-            <input>
+    </statement>
+    <program xml:id="ex_8_13_editor" interactive="activecode" language="python">
+      <input>
 
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_14">
-          <statement>
-            <p>Here is something called an arrowhead curve.  Use 60 degrees.:</p>
-            <pre>YF
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_14">
+    <statement>
+      <p>Here is something called an arrowhead curve.  Use 60 degrees.:</p>
+        <pre>YF
 X -&gt; YF+XF+Y
 Y -&gt; XF-YF-X</pre>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_14_editor">
-            <input>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_14_editor">
+      <input>
 
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q15_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q15_answer" language="python">
+        <input>
 import turtle
 
 def createLSystem(numIters, axiom):
@@ -629,43 +629,41 @@ def main():
 
 main()
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_15">
-          <statement>
-            <p>Try the Peano-Gosper curve.  Use 60 degrees.:</p>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_15">
+    <statement>
+      <p>Try the Peano-Gosper curve.  Use 60 degrees.:</p>
             <pre>FX
 X -&gt; X+YF++YF-FX--FXFX-YF+
 Y -&gt; -FX+YFYF++YF+FX--FX-Y</pre>
-          </statement>
-          <program xml:id="ex_8_15_editor" interactive="activecode" language="python">
-            <input>
+    </statement>
+    <program xml:id="ex_8_15_editor" interactive="activecode" language="python">
+        <input>
 
         </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_16">
-          <statement>
-            <blockquote>
-              <p>The Sierpinski Triangle.  Use 60 degrees.:</p>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_16">
+    <statement>
+      <blockquote>
+        <p>The Sierpinski Triangle.  Use 60 degrees.:</p>
               <pre>FXF--FF--FF
 F -&gt; FF
 X -&gt; --FXF++FXF++FXF--</pre>
-            </blockquote>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_16_editor">
-            <input>
+      </blockquote>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_16_editor">
+      <input>
 
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q17_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q17_answer" language="python">
+        <input>
 import turtle
 
 def createLSystem(numIters, axiom):
@@ -725,43 +723,41 @@ def main():
 
 main()
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_17">
-          <statement>
-            <p>Write a function that implements a substitution cipher.  In a substitution
-                    cipher one letter is substituted for another to garble the message.  For
-                    example A -&gt; Q, B -&gt; T, C -&gt; G etc.  your function should take two
-                    parameters, the message you want to encrypt, and a string that represents
-                    the mapping of the 26 letters in the alphabet.  Your function should
-                    return a string that is the encrypted version of the message.</p>
-          </statement>
-          <program xml:id="ex_8_17_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
 
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_18">
-          <statement>
-            <p>Write a function that decrypts the message from the previous exercise.  It
-                            should also take two parameters.  The encrypted message,
-                            and the mixed up alphabet.  The function should return a string that is
-                            the same as the original unencrypted message.</p>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_18_editor">
-            <input>
+  <exercise label="ex_8_17">
+    <statement>
+      <p>Write a function that implements a substitution cipher.  In a substitution
+              cipher one letter is substituted for another to garble the message.  For
+              example A -&gt; Q, B -&gt; T, C -&gt; G etc.  your function should take two
+              parameters, the message you want to encrypt, and a string that represents
+              the mapping of the 26 letters in the alphabet.  Your function should
+              return a string that is the encrypted version of the message.</p>
+    </statement>
+    <program xml:id="ex_8_17_editor" interactive="activecode" language="python">
+      <input>
 
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q19_answer" language="python">
-              <input>
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_18">
+    <statement>
+      <p>Write a function that decrypts the message from the previous exercise.  It
+              should also take two parameters.  The encrypted message,
+              and the mixed up alphabet.  The function should return a string that is
+              the same as the original unencrypted message.</p>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_18_editor">
+      <input>
+
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q19_answer" language="python">
+        <input>
 def encrypt(message, cipher):
     alphabet = "abcdefghijklmnopqrstuvwxyz"
     encrypted = ''
@@ -788,23 +784,23 @@ def decrypt(encrypted, cipher):
 cipher = "badcfehgjilknmporqtsvuxwzy"
 
 encrypted = encrypt('hello world', cipher)
-print encrypted
+print(encrypted)
 
 decrypted = decrypt(encrypted, cipher)
 print(decrypted)
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_19">
-          <statement>
-            <p>Write a function called  <c>remove_dups</c> that takes a string and creates a new string by only adding those characters that are not already present.  In other words,
-                    there will never be a duplicate letter added to the new string.</p>
-          </statement>
-          <program xml:id="ex_8_19_editor" interactive="activecode" language="python">
-            <input>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_19">
+    <statement>
+      <p>Write a function called  <c>remove_dups</c> that takes a string and creates a new string by only adding those characters that are not already present.  In other words,
+                there will never be a duplicate letter added to the new string.
+      </p>
+    </statement>
+    <program xml:id="ex_8_19_editor" interactive="activecode" language="python">
+      <input>
 def remove_dups(astring):
     # your code here
 
@@ -824,34 +820,33 @@ class myTests(TestCaseGui):
       self.assertEqual(remove_dups("oo"),"o","Tested remove_dups on string 'oo'")
 
 myTests().main()
-        </input>
-          </program>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_20">
-          <statement>
-            <p>Write a function called <c>rot13</c> that uses the Caesar cipher to encrypt a message.
+      </input>
+    </program>
+  </exercise>
+
+  <exercise label="ex_8_20">
+    <statement>
+      <p>Write a function called <c>rot13</c> that uses the Caesar cipher to encrypt a message.
                             The Caesar cipher works like a substitution cipher but each character is replaced
-                            by the character 13 characters to &#x2018;its right' in the alphabet.  So for example
+                            by the character 13 characters to 'its right' in the alphabet.  So for example
                             the letter a becomes the letter n.  If a letter is past the middle of the alphabet
                             then the counting wraps around to the letter a again, so n becomes a, o becomes b
                             and so on.  <em>Hint:</em> Whenever you talk about things wrapping around its a good idea
                             to think of modulo arithmetic.</p>
-          </statement>
-          <program interactive="activecode" language="python" xml:id="ex_8_20_editor">
-            <input>
+    </statement>
+    <program interactive="activecode" language="python" xml:id="ex_8_20_editor">
+      <input>
 def rot13(mess):
     # Your code here
 
 print(rot13('abcde'))
 print(rot13('nopqr'))
 print(rot13(rot13('Since rot13 is symmetric you should see this message')))
-        </input>
-          </program>
-          <solution>
-            <program xml:id="str_q21_answer" language="python">
-              <input>
+      </input>
+    </program>
+    <solution>
+      <program xml:id="str_q21_answer" language="python">
+        <input>
 def rot13(mess):
     alphabet = 'abcdefghijklmnopqrstuvwxyz'
     encrypted = ''
@@ -870,18 +865,17 @@ print(rot13('abcde'))
 print(rot13('nopqr'))
 print(rot13(rot13('since rot thirteen is symmetric you should see this message')))
         </input>
-            </program>
-          </solution>
-        </exercise>
-      </li>
-      <li>
-        <exercise label="ex_8_22">
-          <statement>
+      </program>
+    </solution>
+  </exercise>
+
+  <exercise label="ex_8_22">
+    <statement>
             <p>Modify this code so it prints each subtotal, the total cost, and average price
                     to exactly two decimal places.</p>
-          </statement>
-          <program xml:id="ex_8_22_editor" interactive="activecode" language="python">
-            <input>
+    </statement>
+    <program xml:id="ex_8_22_editor" interactive="activecode" language="python">
+      <input>
 def checkout():
     total = 0
     count = 0
@@ -900,10 +894,7 @@ def checkout():
     print('Average price per item: $', average)
 
 checkout()
-        </input>
-          </program>
-        </exercise>
-      </li>
-    </ol>
-  </p>
+      </input>
+    </program>
+  </exercise>  
 </exercises>


### PR DESCRIPTION
The Strings exercises were showing oddly (double numbers, no question/statement, two mismatched numbers). This commit removes what appears to be unconventional or incorrect use of lists and list items where only exercise was needed. I also updated the spacing and alignment of html tags so that I could tell which parts go together.

I'm not sure if the solution parts need to have both the spaced out text without markdown and the markdown. I did remove the spaced out text since in the locally built version it didn't seem to make a difference. I'd welcome feedback about that.

It's also the case that some exercises do not have labels in them, but I think that was also the case before. I did add some labels where there were labels in the activecode windows but not the exercise. I tried to follow convention that seems present in other exercises.